### PR TITLE
improve text formatting and styling on different routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/og": "^0.6.2",
+    "html-escaper": "^3.0.3",
     "next": "13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/pages/api/og/collection/[collectionId].tsx
+++ b/src/pages/api/og/collection/[collectionId].tsx
@@ -136,7 +136,7 @@ const handler = async (req: NextApiRequest) => {
               <div
                 style={{
                   display: 'flex',
-                  marginTop: 8,
+                  marginTop: 16,
                 }}
               >
                 <p

--- a/src/pages/api/og/collection/[collectionId].tsx
+++ b/src/pages/api/og/collection/[collectionId].tsx
@@ -117,6 +117,7 @@ const handler = async (req: NextApiRequest) => {
               position: 'absolute',
               bottom: '24px',
               left: '24px',
+              marginRight: 25,
             }}
           >
             <p
@@ -132,17 +133,24 @@ const handler = async (req: NextApiRequest) => {
               {title}
             </p>
             {description && (
-              <p
+              <div
                 style={{
-                  fontFamily: "'ABCDiatype-Regular'",
-                  fontSize: '18px',
-                  fontWeight: 400,
-                  lineHeight: '24px',
-                  margin: 0,
+                  display: 'flex',
+                  marginTop: 8,
                 }}
               >
-                {description}
-              </p>
+                <p
+                  style={{
+                    fontFamily: "'ABCDiatype-Regular'",
+                    fontSize: '18px',
+                    fontWeight: 400,
+                    lineHeight: '24px',
+                    margin: 0,
+                  }}
+                >
+                  {description}
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/src/pages/api/og/gallery/[galleryId].tsx
+++ b/src/pages/api/og/gallery/[galleryId].tsx
@@ -37,7 +37,7 @@ const handler = async (req: NextApiRequest) => {
 
     const ABCDiatypeRegularFontData = await ABCDiatypeRegular;
     const alpinaLightFontData = await alpinaLight;
-    
+
     const description = truncateAndStripMarkdown(gallery.description);
     const title = gallery.name ?? '';
     const imageUrls = gallery?.collections
@@ -116,6 +116,7 @@ const handler = async (req: NextApiRequest) => {
               position: 'absolute',
               bottom: '24px',
               left: '24px',
+              marginRight: 25,
             }}
           >
             <p
@@ -131,17 +132,24 @@ const handler = async (req: NextApiRequest) => {
               {title}
             </p>
             {description && (
-              <p
+              <div
                 style={{
-                  fontFamily: "'ABCDiatype-Regular'",
-                  fontSize: '18px',
-                  fontWeight: 400,
-                  lineHeight: '24px',
-                  margin: 0,
+                  display: 'flex',
+                  marginTop: 8,
                 }}
               >
-                {description}
-              </p>
+                <p
+                  style={{
+                    fontFamily: "'ABCDiatype-Regular'",
+                    fontSize: '18px',
+                    fontWeight: 400,
+                    lineHeight: '24px',
+                    margin: 0,
+                  }}
+                >
+                  {description}
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/src/pages/api/og/gallery/[galleryId].tsx
+++ b/src/pages/api/og/gallery/[galleryId].tsx
@@ -9,7 +9,7 @@ import {
   fallbackImageResponse,
 } from '../../../../utils/fallback';
 import { ABCDiatypeRegular, alpinaLight } from '../../../../utils/fonts';
-import { truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
+import { CHAR_LENGTH_TWO_LINE, truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
 import React from 'react';
 
 export const config = {
@@ -38,7 +38,7 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeRegularFontData = await ABCDiatypeRegular;
     const alpinaLightFontData = await alpinaLight;
 
-    const description = truncateAndStripMarkdown(gallery.description);
+    const description = truncateAndStripMarkdown(gallery.description, CHAR_LENGTH_TWO_LINE);
     const title = gallery.name ?? '';
     const imageUrls = gallery?.collections
       ?.filter((collection) => !collection?.hidden && collection.tokens?.length)?.[0]
@@ -135,7 +135,7 @@ const handler = async (req: NextApiRequest) => {
               <div
                 style={{
                   display: 'flex',
-                  marginTop: 8,
+                  marginTop: 16,
                 }}
               >
                 <p

--- a/src/pages/api/og/nft/[tokenId].tsx
+++ b/src/pages/api/og/nft/[tokenId].tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from '@vercel/og';
 import { fetchGraphql, getPreviewUrl } from '../../../../fetch';
-import { removeMarkdownStyling } from '../../../../utils/removeMarkdownStyling';
 import { tokenIdOpengraphQuery } from '../../../../queries/tokenIdOpengraphQuery';
 import { NextApiRequest } from 'next';
-import { truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
+import {
+  CHAR_LENGTH_ONE_LINE,
+  truncateAndStripMarkdown,
+} from '../../../../utils/extractWordsWithinLimit';
 import {
   WIDTH_OPENGRAPH_IMAGE,
   HEIGHT_OPENGRAPH_IMAGE,
@@ -38,7 +40,7 @@ const handler = async (req: NextApiRequest) => {
 
     const tokenImageUrl = getPreviewUrl(token.definition.media);
     const title = token.definition.name;
-    const collectorsNoteText = truncateAndStripMarkdown(token.collectorsNote);
+    const collectorsNoteText = truncateAndStripMarkdown(token.collectorsNote, CHAR_LENGTH_ONE_LINE);
     const description = truncateAndStripMarkdown(token.definition.description);
 
     const ABCDiatypeRegularFontData = await ABCDiatypeRegular;
@@ -99,6 +101,7 @@ const handler = async (req: NextApiRequest) => {
               position: 'absolute',
               bottom: '24px',
               left: '24px',
+              marginRight: 25,
             }}
           >
             <p
@@ -114,17 +117,25 @@ const handler = async (req: NextApiRequest) => {
               {title}
             </p>
             {description && (
-              <p
+              <div
                 style={{
-                  fontFamily: "'ABCDiatype-Regular'",
-                  fontSize: '18px',
-                  fontWeight: 400,
-                  lineHeight: '24px',
-                  margin: 0,
+                  display: 'flex',
+                  marginTop: 8,
                 }}
               >
-                {description}
-              </p>
+                <p
+                  style={{
+                    fontFamily: "'ABCDiatype-Regular'",
+                    fontSize: '18px',
+                    fontWeight: 400,
+                    lineHeight: '24px',
+
+                    margin: 0,
+                  }}
+                >
+                  {description}
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/src/pages/api/og/nft/[tokenId].tsx
+++ b/src/pages/api/og/nft/[tokenId].tsx
@@ -5,6 +5,7 @@ import { tokenIdOpengraphQuery } from '../../../../queries/tokenIdOpengraphQuery
 import { NextApiRequest } from 'next';
 import {
   CHAR_LENGTH_ONE_LINE,
+    CHAR_LENGTH_TWO_LINE,
   truncateAndStripMarkdown,
 } from '../../../../utils/extractWordsWithinLimit';
 import {
@@ -40,8 +41,8 @@ const handler = async (req: NextApiRequest) => {
 
     const tokenImageUrl = getPreviewUrl(token.definition.media);
     const title = token.definition.name;
-    const collectorsNoteText = truncateAndStripMarkdown(token.collectorsNote, CHAR_LENGTH_ONE_LINE);
-    const description = truncateAndStripMarkdown(token.definition.description);
+    const collectorsNoteText = truncateAndStripMarkdown(token.collectorsNote);
+    const description = truncateAndStripMarkdown(token.definition.description, CHAR_LENGTH_TWO_LINE);
 
     const ABCDiatypeRegularFontData = await ABCDiatypeRegular;
     const alpinaLightFontData = await alpinaLight;
@@ -120,7 +121,7 @@ const handler = async (req: NextApiRequest) => {
               <div
                 style={{
                   display: 'flex',
-                  marginTop: 8,
+                  marginTop: 16,
                 }}
               >
                 <p

--- a/src/pages/api/og/nft/[tokenId].tsx
+++ b/src/pages/api/og/nft/[tokenId].tsx
@@ -4,8 +4,7 @@ import { fetchGraphql, getPreviewUrl } from '../../../../fetch';
 import { tokenIdOpengraphQuery } from '../../../../queries/tokenIdOpengraphQuery';
 import { NextApiRequest } from 'next';
 import {
-  CHAR_LENGTH_ONE_LINE,
-    CHAR_LENGTH_TWO_LINE,
+  CHAR_LENGTH_TWO_LINE,
   truncateAndStripMarkdown,
 } from '../../../../utils/extractWordsWithinLimit';
 import {
@@ -42,7 +41,10 @@ const handler = async (req: NextApiRequest) => {
     const tokenImageUrl = getPreviewUrl(token.definition.media);
     const title = token.definition.name;
     const collectorsNoteText = truncateAndStripMarkdown(token.collectorsNote);
-    const description = truncateAndStripMarkdown(token.definition.description, CHAR_LENGTH_TWO_LINE);
+    const description = truncateAndStripMarkdown(
+      token.definition.description,
+      CHAR_LENGTH_TWO_LINE,
+    );
 
     const ABCDiatypeRegularFontData = await ABCDiatypeRegular;
     const alpinaLightFontData = await alpinaLight;

--- a/src/pages/api/og/post/[postId].tsx
+++ b/src/pages/api/og/post/[postId].tsx
@@ -7,7 +7,7 @@ import {
   fallbackImageResponse,
 } from '../../../../utils/fallback';
 import { ABCDiatypeRegular, ABCDiatypeBold, alpinaLight } from '../../../../utils/fonts';
-import { truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
+import { CHAR_LENGTH_ONE_LINE, truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
 
 import { postIdQuery } from '../../../../queries/postIdOpengraphQuery';
 import { NextApiRequest } from 'next';
@@ -69,7 +69,7 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
-    const caption = truncateAndStripMarkdown(post?.caption);
+    const caption = truncateAndStripMarkdown(post?.caption, CHAR_LENGTH_ONE_LINE);
     const captionPlaintext =
       caption?.length === 0 ? 'View this post on gallery.so' : caption;
 

--- a/src/pages/api/og/user/[username].tsx
+++ b/src/pages/api/og/user/[username].tsx
@@ -10,7 +10,7 @@ import {
   fallbackImageResponse,
 } from '../../../../utils/fallback';
 import { ABCDiatypeRegular, ABCDiatypeBold, alpinaLight } from '../../../../utils/fonts';
-import { truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
+import { CHAR_LENGTH_TWO_LINE, truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
 import React from 'react';
 
 export const config = {
@@ -36,7 +36,7 @@ const handler = async (req: NextApiRequest) => {
       return fallbackImageResponse;
     }
 
-    const description = truncateAndStripMarkdown(user?.bio ?? '');
+    const description = truncateAndStripMarkdown(user?.bio ?? '', CHAR_LENGTH_TWO_LINE);
     const nonEmptyGalleries = user.galleries?.filter(
       (gallery) => gallery?.collections?.some((collection) => collection?.tokens?.length),
     );
@@ -141,7 +141,7 @@ const handler = async (req: NextApiRequest) => {
               <div
                 style={{
                   display: 'flex',
-                  marginTop: 8,
+                  marginTop: 16,
                 }}
               >
                 <p

--- a/src/pages/api/og/user/[username].tsx
+++ b/src/pages/api/og/user/[username].tsx
@@ -10,7 +10,7 @@ import {
   fallbackImageResponse,
 } from '../../../../utils/fallback';
 import { ABCDiatypeRegular, ABCDiatypeBold, alpinaLight } from '../../../../utils/fonts';
-import { removeMarkdownStyling } from '../../../../utils/removeMarkdownStyling';
+import { truncateAndStripMarkdown } from '../../../../utils/extractWordsWithinLimit';
 import React from 'react';
 
 export const config = {
@@ -36,7 +36,7 @@ const handler = async (req: NextApiRequest) => {
       return fallbackImageResponse;
     }
 
-    const description = removeMarkdownStyling(user.bio.split('\n')[0] ?? '');
+    const description = truncateAndStripMarkdown(user?.bio ?? '');
     const nonEmptyGalleries = user.galleries?.filter(
       (gallery) => gallery?.collections?.some((collection) => collection?.tokens?.length),
     );
@@ -122,6 +122,7 @@ const handler = async (req: NextApiRequest) => {
               position: 'absolute',
               bottom: '24px',
               left: '24px',
+              marginRight: 25,
             }}
           >
             <p
@@ -137,17 +138,24 @@ const handler = async (req: NextApiRequest) => {
               {username}
             </p>
             {description && (
-              <p
+              <div
                 style={{
-                  fontFamily: "'ABCDiatype-Regular'",
-                  fontSize: '18px',
-                  fontWeight: 400,
-                  lineHeight: '24px',
-                  margin: 0,
+                  display: 'flex',
+                  marginTop: 8,
                 }}
               >
-                {description}
-              </p>
+                <p
+                  style={{
+                    fontFamily: "'ABCDiatype-Regular'",
+                    fontSize: '18px',
+                    fontWeight: 400,
+                    lineHeight: '24px',
+                    margin: 0,
+                  }}
+                >
+                  {description}
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/src/utils/extractWordsWithinLimit.ts
+++ b/src/utils/extractWordsWithinLimit.ts
@@ -1,22 +1,5 @@
 import { removeMarkdownStyling } from './removeMarkdownStyling';
-
-function customUnescape(str: string) {
-  return str
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#34;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&cent;/g, '¢')
-    .replace(/&pound;/g, '£')
-    .replace(/&yen;/g, '¥')
-    .replace(/&euro;/g, '€')
-    .replace(/&copy;/g, '©')
-    .replace(/&reg;/g, '®')
-    .replace(/&trade;/g, '™');
-}
+const { unescape } = require('html-escaper');
 
 export const CHAR_LENGTH_ONE_LINE = 160;
 export const CHAR_LENGTH_TWO_LINE = 330;
@@ -56,7 +39,7 @@ export function extractWordsWithinLimit(text: string, charLimit: number = CHAR_L
 }
 
 export function truncateAndStripMarkdown(text: string, charLimit?: number) {
-  const sanitizedText = customUnescape(text);
+  const sanitizedText = unescape(text);
   const cleanText = removeMarkdownStyling(sanitizedText ?? '');
   const truncatedText = extractWordsWithinLimit(cleanText, charLimit);
   return truncatedText ?? '';

--- a/src/utils/extractWordsWithinLimit.ts
+++ b/src/utils/extractWordsWithinLimit.ts
@@ -21,11 +21,8 @@ function customUnescape(str: string) {
 export const CHAR_LENGTH_ONE_LINE = 160;
 export const CHAR_LENGTH_TWO_LINE = 330;
 
-export function extractWordsWithinLimit(
-  inputString: string,
-  charLimit: number = CHAR_LENGTH_ONE_LINE,
-) {
-  const words = inputString?.split(' ') ?? [];
+export function extractWordsWithinLimit(text: string, charLimit: number = CHAR_LENGTH_ONE_LINE) {
+  const words = text?.split(' ') ?? [];
   let result = [];
   let characterCount = 0;
 
@@ -37,7 +34,21 @@ export function extractWordsWithinLimit(
     characterCount += word.length + 1; // Add 1 for the space
   }
 
-  return result.join(' ').trim() + '...';
+  let truncatedText = result.join(' ').trim();
+
+  if (truncatedText?.length > 0) {
+    return truncatedText + '...';
+
+    // TODO(rohan): improve logic here
+  } else if (words?.[0]?.length > 0) {
+    if (words[0].length === charLimit) {
+      return words[0];
+    }
+
+    return words[0].slice(0, charLimit - 3) + '...';
+  }
+
+  return truncatedText;
 }
 
 export function truncateAndStripMarkdown(text: string, charLimit?: number) {

--- a/src/utils/extractWordsWithinLimit.ts
+++ b/src/utils/extractWordsWithinLimit.ts
@@ -37,9 +37,13 @@ export function extractWordsWithinLimit(text: string, charLimit: number = CHAR_L
   let truncatedText = result.join(' ').trim();
 
   if (truncatedText?.length > 0) {
-    return truncatedText + '...';
+    if (truncatedText.length < text.length) {
+      return truncatedText + '...';
+    }
+    return truncatedText;
 
     // TODO(rohan): improve logic here
+    // return first word if first word length > charLimit
   } else if (words?.[0]?.length > 0) {
     if (words[0].length === charLimit) {
       return words[0];

--- a/src/utils/extractWordsWithinLimit.ts
+++ b/src/utils/extractWordsWithinLimit.ts
@@ -1,6 +1,30 @@
 import { removeMarkdownStyling } from './removeMarkdownStyling';
 
-export function extractWordsWithinLimit(inputString: string, charLimit: number = 160) {
+function customUnescape(str: string) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#34;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&cent;/g, '¢')
+    .replace(/&pound;/g, '£')
+    .replace(/&yen;/g, '¥')
+    .replace(/&euro;/g, '€')
+    .replace(/&copy;/g, '©')
+    .replace(/&reg;/g, '®')
+    .replace(/&trade;/g, '™');
+}
+
+export const CHAR_LENGTH_ONE_LINE = 160;
+export const CHAR_LENGTH_TWO_LINE = 330;
+
+export function extractWordsWithinLimit(
+  inputString: string,
+  charLimit: number = CHAR_LENGTH_ONE_LINE,
+) {
   const words = inputString?.split(' ') ?? [];
   let result = [];
   let characterCount = 0;
@@ -13,11 +37,12 @@ export function extractWordsWithinLimit(inputString: string, charLimit: number =
     characterCount += word.length + 1; // Add 1 for the space
   }
 
-  return result.join(' ');
+  return result.join(' ').trim() + '...';
 }
 
 export function truncateAndStripMarkdown(text: string, charLimit?: number) {
-  const cleanText = removeMarkdownStyling(text ?? '');
+  const sanitizedText = customUnescape(text);
+  const cleanText = removeMarkdownStyling(sanitizedText ?? '');
   const truncatedText = extractWordsWithinLimit(cleanText, charLimit);
   return truncatedText ?? '';
 }


### PR DESCRIPTION
we unescape the text (added a custom unescape function), remove the markdown styling and truncate text to one or two lines in the routes

### collection route
<img width="1217" alt="Screenshot 2024-02-21 at 1 08 21 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/8fbe73d8-2476-4b8a-bdd7-446de5934cf1">



### user route
<img width="1219" alt="Screenshot 2024-02-21 at 12 46 01 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/0ad4a364-e284-4152-b1ff-9c0eb5269a1f">


### gallery route
<img width="1214" alt="Screenshot 2024-02-21 at 12 54 32 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/ded1d297-b756-44a8-8bd6-b4292c0b83a0">


### token route
<img width="1221" alt="Screenshot 2024-02-21 at 12 49 02 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/bb39d4e8-ebda-47ef-a4b8-582d130efa0b">


