### PR TITLE
increase excessContainer space to fit splash images

### DIFF
--- a/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
+++ b/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
@@ -114,7 +114,7 @@ const handler = async (req: NextApiRequest) => {
 
       const distanceFromTop = longName ? 220 : 240;
       const distanceFromLeft = 340;
-      const excessContainerSize = 70;
+      const excessContainerSize = 100;
       const textLength = 510;
 
       const textAreaBoundingBox = {


### PR DESCRIPTION
### Before
<img width="539" alt="Screenshot 2024-02-27 at 6 35 57 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/9f8046f6-f68f-4489-a993-0908d98ef4a7">

### After
<img width="533" alt="Screenshot 2024-02-27 at 6 36 15 PM" src="https://github.com/gallery-so/opengraph/assets/49758803/4e136a1b-8d74-4771-a527-3f4f52d38235">
