### PR TITLE
fix aspect ratio bug on community fcframe

### DIFF
--- a/src/utils/framePostHandler.ts
+++ b/src/utils/framePostHandler.ts
@@ -122,7 +122,7 @@ export async function framePostHandler({
     const mainPosition = Number(position) % tokensLength;
 
     // if mainPosition is 0 we want to show splash screen in 1.91:1
-    squareAspectRatio = determineAspectRatio(tokens, position, mainPosition !== 0);
+    squareAspectRatio = determineAspectRatio(tokens, position, mainPosition === 0);
   } else if (frameType === 'UserFrame' && position) {
     const username = url.searchParams.get('username');
     if (!username || typeof username !== 'string') {


### PR DESCRIPTION
### Before

<img width="591" alt="Screenshot 2024-03-06 at 00 21 20" src="https://github.com/gallery-so/opengraph/assets/49758803/52bcf3b9-984b-4bab-a707-64344fdd1d73">

### After ("1:1" aspect ratio meta tag returned)

<img width="556" alt="Screenshot 2024-03-06 at 00 21 09" src="https://github.com/gallery-so/opengraph/assets/49758803/3f9a1d0e-6651-43ad-bde6-318770c631d8">
