### PR TITLE
[GAL-5298] improvements to Splash Screen in Frames

### DIFF
--- a/src/pages/api/og/collection/[collectionId]/fcframe.tsx
+++ b/src/pages/api/og/collection/[collectionId]/fcframe.tsx
@@ -49,7 +49,7 @@ const handler = async (req: NextApiRequest) => {
 
     const tokensToDisplay = getPreviewTokens(
       collection.tokens.map((el) => el?.token),
-      `${Number(position) - 1}`
+      `${Number(position) - 1}`,
     );
 
     // if no position is explicitly provided, serve splash image
@@ -60,6 +60,7 @@ const handler = async (req: NextApiRequest) => {
         titleText: collection.name,
         numSplashImages: 5,
         tokens: collection.tokens.map((el) => el?.token),
+        showUsername: true,
       });
     }
 
@@ -288,7 +289,7 @@ const handler = async (req: NextApiRequest) => {
             weight: 500,
           },
         ],
-      }
+      },
     );
   } catch (e) {
     console.log('error: ', e);

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -64,6 +64,7 @@ const handler = async (req: NextApiRequest) => {
         titleText: gallery.name,
         numSplashImages: 5,
         tokens,
+        showUsername: true,
       });
     }
 
@@ -290,7 +291,7 @@ const handler = async (req: NextApiRequest) => {
             weight: 500,
           },
         ],
-      }
+      },
     );
   } catch (e) {
     console.log('error: ', e);

--- a/src/queries/fcframeCollectionIdOpengraphQuery.tsx
+++ b/src/queries/fcframeCollectionIdOpengraphQuery.tsx
@@ -12,6 +12,9 @@ export const fcframeCollectionIdOpengraphQuery = `
         name
         tokens {
           token {
+            owner {
+              username
+            }
             dbid
             definition {
               name

--- a/src/queries/fcframeGalleryIdOpengraphQuery.ts
+++ b/src/queries/fcframeGalleryIdOpengraphQuery.ts
@@ -14,6 +14,9 @@ export const fcframeGalleryIdOpengraphQuery = `
           hidden
           tokens {
             token {
+              owner {
+                username
+              }
               dbid
               definition {
                 name

--- a/src/utils/splashScreen.tsx
+++ b/src/utils/splashScreen.tsx
@@ -92,7 +92,7 @@ export function calcRandomPosition({
   textAreaBoundingBox,
   // the positions of existing images
   existingPositions,
-  //
+  // the size of the username text for collection/gallery frames
   usernameContainerSize,
 }: BaseProps & {
   elementSize: Dimensions;
@@ -117,8 +117,9 @@ export function calcRandomPosition({
 
     let overlapsUsernameArea = false;
     if (usernameContainerSize) {
-      const lowerBound = (containerSize.width - usernameContainerSize.width) / 2 - 110;
-      const upperBound = (containerSize.width + usernameContainerSize.width) / 2 + 50;
+      const offsetPadding = 100;
+      const lowerBound = (containerSize.width - usernameContainerSize.width) / 2 - offsetPadding;
+      const upperBound = (containerSize.width + usernameContainerSize.width) / 2 + offsetPadding;
       overlapsUsernameArea = false;
       if (pos.top > containerSize.height / 2) {
         if (pos.left < upperBound && pos.left > lowerBound) {
@@ -148,15 +149,6 @@ export function calcRandomPosition({
       }
     }
 
-    if (!(overlapTitleArea || overlapsUsernameArea || overlapsWithOtherImages)) {
-      const lowerBound = (containerSize.width - usernameContainerSize.width) / 2 - 140;
-      const upperBound = (containerSize.width + usernameContainerSize.width) / 2 - 90;
-      console.log('pos.left', pos.left);
-      console.log('pos.top', pos.top);
-      console.log('upperBound', upperBound);
-      console.log('lowerBound', lowerBound);
-      console.log(' elementSize.width', elementSize.width);
-    }
     return overlapTitleArea || overlapsUsernameArea || overlapsWithOtherImages;
   }
 
@@ -170,7 +162,6 @@ export function calcRandomPosition({
 
     isOverlapping = checkOverlap(position);
 
-    console.log('isOverlapping', isOverlapping);
     if (!isOverlapping) {
       break;
     }
@@ -238,8 +229,6 @@ export async function generateSplashImageResponse({
     bottom: distanceFromTop + textHeight,
     right: distanceFromLeft + textLength,
   };
-  console.log('containerWidth', WIDTH_OPENGRAPH_IMAGE + excessContainerSize);
-  console.log('containerHeight', HEIGHT_OPENGRAPH_IMAGE + excessContainerSize);
 
   const positions = generatePositionsForSplashImages({
     numElements: numSplashImages,
@@ -370,7 +359,7 @@ export async function generateSplashImageResponse({
         {
           name: 'GT Alpina Italic',
           data: alpinaLightItalicFontData,
-          style: 'normal',
+          style: 'italic',
           weight: 500,
         },
       ],

--- a/src/utils/splashScreen.tsx
+++ b/src/utils/splashScreen.tsx
@@ -5,7 +5,7 @@ import { truncateAndStripMarkdown } from './extractWordsWithinLimit';
 import { HEIGHT_OPENGRAPH_IMAGE, WIDTH_OPENGRAPH_IMAGE, fallbackImageResponse } from './fallback';
 import { alpinaLight, alpinaLightItalic } from './fonts';
 
-const CHAR_LENGTH_CENTER_TITLE = 44;
+const CHAR_LENGTH_CENTER_TITLE = 56;
 const calcLineHeightPx = (largeFont: boolean) => (largeFont ? 160 : 100);
 
 type Position = { left: number; top: number };
@@ -50,8 +50,10 @@ function generatePositionsForSplashImages({
     let dimensionToUse = pickRandomInt(possibleElementSizes);
     do {
       // as we try more attempts, use a smaller size
-      if (attempts > 500) {
+      if (attempts > 400) {
         dimensionToUse = possibleElementSizes[1];
+      } else if (attempts > 700) {
+        dimensionToUse = possibleElementSizes[2];
       }
 
       newPosition = calcRandomPosition({
@@ -241,7 +243,7 @@ export async function generateSplashImageResponse({
 
   const positions = generatePositionsForSplashImages({
     numElements: numSplashImages,
-    possibleElementSizes: [360, 200],
+    possibleElementSizes: [360, 200, 170],
     containerSize: {
       width: WIDTH_OPENGRAPH_IMAGE + excessContainerSize,
       height: HEIGHT_OPENGRAPH_IMAGE + excessContainerSize,
@@ -314,6 +316,7 @@ export async function generateSplashImageResponse({
             justifyContent: 'center',
             alignItems: 'center',
             height: '100%',
+            width: '100%',
             position: 'relative',
           }}
         >
@@ -329,29 +332,28 @@ export async function generateSplashImageResponse({
               style={{
                 fontFamily: "'GT Alpina Italic'",
                 fontSize,
-                width: '520px',
-                margin: 'auto',
-                textAlign: 'center',
+                maxWidth: '520px',
                 letterSpacing,
+                textAlign: 'center',
               }}
             >
               {displayedTitle}
             </p>
-            {showUsername && (
-              <p
-                style={{
-                  position: 'absolute',
-                  fontFamily: "'GT Alpina'",
-                  fontSize: '48px',
-                  fontStyle: 'normal',
-                  top: '300px',
-                  textAlign: 'center',
-                }}
-              >
-                {ownerName}
-              </p>
-            )}
           </div>
+          {showUsername && (
+            <p
+              style={{
+                position: 'absolute',
+                fontFamily: "'GT Alpina'",
+                fontSize: '48px',
+                fontStyle: 'normal',
+                bottom: 7,
+                textAlign: 'center',
+              }}
+            >
+              {ownerName}
+            </p>
+          )}
         </div>
       </div>
     ),


### PR DESCRIPTION
Changes
- support longer collection and gallery names in splash screen
- show username in collection and gallery splash screens

| Before | After |
|--------|--------|
| ![Screenshot 2024-03-20 at 15 41 02](https://github.com/gallery-so/opengraph/assets/49758803/d52a764b-dd47-461f-a934-942e86392729) | ![Screenshot 2024-03-20 at 12 56 58](https://github.com/gallery-so/opengraph/assets/49758803/8c9f606d-7740-4869-89cb-081f61c54825) |

## Other outputs for different cases
![Screenshot 2024-03-20 at 15 32 43](https://github.com/gallery-so/opengraph/assets/49758803/959c225e-7b2b-41b3-a916-7abf474e2a06)
![Screenshot 2024-03-20 at 15 32 16](https://github.com/gallery-so/opengraph/assets/49758803/e981767f-e74e-4e15-8894-b8e11e233293)
![Screenshot 2024-03-20 at 14 27 58](https://github.com/gallery-so/opengraph/assets/49758803/809baec2-cc77-47ad-9e4c-c806f61b8413)
![Screenshot 2024-03-20 at 15 40 22](https://github.com/gallery-so/opengraph/assets/49758803/6946f4e1-6c4d-4ff1-84c2-61f0020e471d)

