### PR TITLE
temp fix for the WLTA winners' gallery frames

### DIFF
--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -51,13 +51,15 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
-    const temoIgnoreTokensWithIds = ['2bT2G4iiB0LfMVZ6k3YfdiIs8sU'];
+    const tempIgnoreTokensWithIds = ['2bT2G4iiB0LfMVZ6k3YfdiIs8sU', '2bhcj7DcaxAROSHodJH99glBt17'];
 
     const tokens = gallery.collections
       .filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
       .map((el) => el?.token)
-      .filter((token) => !temoIgnoreTokensWithIds.includes(token.dbid));
+      .filter((token) => {
+        return !tempIgnoreTokensWithIds.filter((tokenId) => token.dbid === tokenId).length;
+      });
 
     // if no position is explicitly provided, serve splash image
     let showSplashScreen = !position;

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -51,11 +51,16 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
+    // TODO(Rohan): remove these once we can support these assets
+    // temp fix to get the WLTA winner gallery frames working
     const tempIgnoreTokensWithIds = [
       '2bT2G4iiB0LfMVZ6k3YfdiIs8sU',
       '2bT2FzE3iB59Zm5PTUTAhM9lor7',
       '2blxlBBmty8MFX3qLevWqOXorJX',
       '2bhcj7DcaxAROSHodJH99glBt17',
+      '2cPoZ0hrNJbaiNsMOvLkeHrfIFc',
+      '2bT2FzEWNvgShbVLFwWDMnZ36ud',
+      '2cPoYvcYW2xsDoSHhJn9YoMFjY2',
     ];
 
     const tokens = gallery.collections

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -51,10 +51,13 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
+    const temoIgnoreTokensWithIds = ['2bT2G4iiB0LfMVZ6k3YfdiIs8sU'];
+
     const tokens = gallery.collections
       .filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
-      .map((el) => el?.token);
+      .map((el) => el?.token)
+      .filter((token) => !temoIgnoreTokensWithIds.includes(token.dbid));
 
     // if no position is explicitly provided, serve splash image
     let showSplashScreen = !position;

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -51,7 +51,11 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
-    const tempIgnoreTokensWithIds = ['2bT2G4iiB0LfMVZ6k3YfdiIs8sU', '2bhcj7DcaxAROSHodJH99glBt17'];
+    const tempIgnoreTokensWithIds = [
+      '2bT2G4iiB0LfMVZ6k3YfdiIs8sU',
+      '2bhcj7DcaxAROSHodJH99glBt17',
+      '2dbdYbvUNK8t51wBqrIuqk2hV4N',
+    ];
 
     const tokens = gallery.collections
       .filter((collection) => !collection?.hidden)

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -53,8 +53,9 @@ const handler = async (req: NextApiRequest) => {
 
     const tempIgnoreTokensWithIds = [
       '2bT2G4iiB0LfMVZ6k3YfdiIs8sU',
+      '2bT2FzE3iB59Zm5PTUTAhM9lor7',
+      '2blxlBBmty8MFX3qLevWqOXorJX',
       '2bhcj7DcaxAROSHodJH99glBt17',
-      '2dbdYbvUNK8t51wBqrIuqk2hV4N',
     ];
 
     const tokens = gallery.collections


### PR DESCRIPTION
### Before

![Screenshot 2024-03-20 at 1 38 55 PM](https://github.com/gallery-so/opengraph/assets/49758803/8cc5a018-d5b3-4e0a-9810-6b1523a7db75)

### After

![Screenshot 2024-03-25 at 15 12 04](https://github.com/gallery-so/opengraph/assets/49758803/cab2ef4f-4904-435e-b06b-9ef93c7c2bc5)
![Screenshot 2024-03-25 at 15 12 11](https://github.com/gallery-so/opengraph/assets/49758803/f13f515e-feaf-469f-b381-8d8f6270890a)


