### PR TITLE
cleanup + fix looping error

### DIFF
--- a/src/pages/api/og/collection/[collectionId].tsx
+++ b/src/pages/api/og/collection/[collectionId].tsx
@@ -29,13 +29,7 @@ const handler = async (req: NextApiRequest) => {
       return fallbackImageResponse;
     }
 
-    const imageUrls = collection.tokens
-      ?.map((element) => {
-        return element?.token ? getPreviewUrl(element?.token?.definition?.media) : null;
-      })
-      .slice(0, 4);
-
-    if (!imageUrls) {
+    if (!collection?.tokens) {
       return fallbackImageResponse;
     }
 

--- a/src/pages/api/og/collection/[collectionId].tsx
+++ b/src/pages/api/og/collection/[collectionId].tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NextApiRequest } from 'next';
 
-import { fetchGraphql, getPreviewUrl } from '../../../../fetch';
+import { fetchGraphql } from '../../../../fetch';
 import { fcframeCollectionIdOpengraphQuery } from '../../../../queries/fcframeCollectionIdOpengraphQuery';
 import { fallbackImageResponse } from '../../../../utils/fallback';
 import { generateSplashImageResponse } from '../../../../utils/splashScreen';

--- a/src/pages/api/og/collection/[collectionId]/fcframe.tsx
+++ b/src/pages/api/og/collection/[collectionId]/fcframe.tsx
@@ -12,7 +12,10 @@ import {
 import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
 import React from 'react';
-import { generateSplashImageResponse } from '../../../../../utils/splashScreen';
+import {
+  generateSplashImageResponse,
+  shouldShowSplashScreen,
+} from '../../../../../utils/splashScreen';
 import {
   containerStyle,
   blurredLeftSideImageStyle,
@@ -59,19 +62,16 @@ const handler = async (req: NextApiRequest) => {
       return fallbackImageResponse;
     }
 
-    const tokensToDisplay = getPreviewTokens(
-      collection.tokens.map((el) => el?.token),
-      `${Number(position) - 1}`,
-    );
+    let tokens = collection.tokens.map((el) => el?.token);
+    const tokensToDisplay = getPreviewTokens(tokens, `${Number(position) - 1}`);
 
     // if no position is explicitly provided, serve splash image
-    let showSplashScreen = !position;
-
+    let showSplashScreen = shouldShowSplashScreen({ position, carouselLength: tokens?.length + 1 });
     if (showSplashScreen) {
       return generateSplashImageResponse({
         titleText: collection.name,
         numSplashImages: 5,
-        tokens: collection.tokens.map((el) => el?.token),
+        tokens: tokens,
         showUsername: true,
       });
     }

--- a/src/pages/api/og/collection/[collectionId]/fcframe.tsx
+++ b/src/pages/api/og/collection/[collectionId]/fcframe.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from '@vercel/og';
 import { fetchGraphql } from '../../../../../fetch';
@@ -11,7 +13,6 @@ import {
 } from '../../../../../utils/fallback';
 import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
-import React from 'react';
 import {
   generateSplashImageResponse,
   shouldShowSplashScreen,
@@ -65,7 +66,6 @@ const handler = async (req: NextApiRequest) => {
     let tokens = collection.tokens.map((el) => el?.token);
     const tokensToDisplay = getPreviewTokens(tokens, `${Number(position) - 1}`);
 
-    // if no position is explicitly provided, serve splash image
     let showSplashScreen = shouldShowSplashScreen({ position, carouselLength: tokens?.length + 1 });
     if (showSplashScreen) {
       return generateSplashImageResponse({

--- a/src/pages/api/og/collection/[collectionId]/fcframe.tsx
+++ b/src/pages/api/og/collection/[collectionId]/fcframe.tsx
@@ -13,6 +13,18 @@ import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
 import React from 'react';
 import { generateSplashImageResponse } from '../../../../../utils/splashScreen';
+import {
+  containerStyle,
+  blurredLeftSideImageStyle,
+  blurredRightSideImageStyle,
+  centeredImageContainerStyle,
+  imageDescriptionStyle,
+  textStyle,
+  boldTextStyle,
+  imageStyle,
+  columnFlexStyle,
+  columnAltFlexStyle,
+} from '../../../../../styles';
 
 export const config = {
   runtime: 'edge',
@@ -74,194 +86,54 @@ const handler = async (req: NextApiRequest) => {
 
     return new ImageResponse(
       (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            width: '100%',
-            height: '100%',
-            minHeight: 200,
-            backgroundColor: '#ffffff',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              marginLeft: '-25%',
-              filter: 'blur(6px)',
-              opacity: 0.26,
-            }}
-          >
+        <div style={containerStyle}>
+          <div style={blurredLeftSideImageStyle}>
             {leftToken ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={columnAltFlexStyle}>
                 <img
                   width="500"
                   height="500"
                   src={leftToken?.src}
-                  style={{
-                    maxWidth: '500px',
-                    maxHeight: '500px',
-                    display: 'block',
-                    objectFit: 'contain',
-                  }}
+                  style={imageStyle}
                   alt="left token"
                 />
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    filter: 'blur(2px)',
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Regular'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {leftToken?.name}
-                  </p>
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Bold'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {leftToken?.communityName}
-                  </p>
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{leftToken?.name}</p>
+                  <p style={boldTextStyle}>{leftToken?.communityName}</p>
                 </div>
               </div>
             ) : null}
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-
-              position: 'absolute',
-              width: '100%',
-
-              height: '100%',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '8px',
-              }}
-            >
+          <div style={centeredImageContainerStyle}>
+            <div style={columnFlexStyle}>
               <img
                 width="500"
                 height="500"
                 src={centerToken?.src}
-                style={{
-                  maxWidth: '500px',
-                  maxHeight: '500px',
-                  display: 'block',
-                  objectFit: 'contain',
-                }}
+                style={imageStyle}
                 alt="center token"
               />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'flex-start',
-                }}
-              >
-                <p
-                  style={{
-                    fontFamily: "'ABCDiatype-Regular'",
-                    fontSize: '14px',
-                    fontWeight: 'light',
-                    lineHeight: '20px',
-                    margin: 0,
-                  }}
-                >
-                  {centerToken?.name}
-                </p>
-                <p
-                  style={{
-                    fontFamily: "'ABCDiatype-Bold'",
-                    fontSize: '14px',
-                    fontWeight: 400,
-                    lineHeight: '20px',
-                    margin: 0,
-                  }}
-                >
-                  {centerToken?.communityName}
-                </p>
+              <div style={columnAltFlexStyle}>
+                <p style={textStyle}>{centerToken?.name}</p>
+                <p style={boldTextStyle}>{centerToken?.communityName}</p>
               </div>
             </div>
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              marginRight: '-25%',
-              filter: 'blur(6px)',
-              opacity: 0.26,
-            }}
-          >
+          <div style={blurredRightSideImageStyle}>
             {rightToken ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={columnAltFlexStyle}>
                 <img
                   width="500"
                   height="500"
                   src={rightToken?.src}
-                  style={{
-                    maxWidth: '500px',
-                    maxHeight: '500px',
-                    display: 'block',
-                    objectFit: 'contain',
-                  }}
+                  style={imageStyle}
                   alt="right token"
                 />
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    filter: 'blur(2px)',
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Regular'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {rightToken?.name}
-                  </p>
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Bold'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {rightToken?.communityName}
-                  </p>
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{rightToken?.name}</p>
+                  <p style={boldTextStyle}>{rightToken?.communityName}</p>
                 </div>
               </div>
             ) : null}

--- a/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
+++ b/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
@@ -14,6 +14,19 @@ import { framePostHandler, isImageTall } from '../../../../../../utils/framePost
 import { getPreviewTokens } from '../../../../../../utils/getPreviewTokens';
 import { generateSplashImageResponse } from '../../../../../../utils/splashScreen';
 
+import {
+  containerStyle,
+  blurredLeftSideImageStyle,
+  blurredRightSideImageStyle,
+  centeredImageContainerStyle,
+  imageDescriptionStyle,
+  textStyle,
+  boldTextStyle,
+  imageStyle,
+  columnFlexStyle,
+  columnAltFlexStyle,
+} from '../../../../../../styles';
+
 export const config = {
   runtime: 'edge',
 };
@@ -102,203 +115,38 @@ const handler = async (req: NextApiRequest) => {
       if (squareAspectRatio) {
         return new ImageResponse(
           (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                width: '100%',
-                height: '100%',
-                minHeight: 200,
-                backgroundColor: '#ffffff',
-                gap: leftToken ? 460 : 800,
-                alignItems: 'center',
-              }}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  position: 'relative',
-                  marginLeft: '-65%',
-                  filter: 'blur(6px)',
-                  opacity: 0.26,
-                }}
-              >
+            <div style={containerStyle}>
+              <div style={blurredLeftSideImageStyle}>
                 {leftToken ? (
-                  <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <img
-                      src={leftToken?.src}
-                      style={{
-                        maxWidth: '340px',
-                        maxHeight: '380px',
-                        display: 'block',
-                        objectFit: 'contain',
-                      }}
-                      alt="left token"
-                    />
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        marginTop: 8,
-                        justifyContent: 'flex-start',
-                        filter: 'blur(2px)',
-                      }}
-                    >
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Regular'",
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          lineHeight: '20px',
-                          margin: 0,
-                        }}
-                      >
-                        {leftToken?.name}
-                      </p>
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Bold'",
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          lineHeight: '20px',
-                          margin: 0,
-                        }}
-                      >
-                        {leftToken?.ownerName}
-                      </p>
+                  <div style={columnAltFlexStyle}>
+                    <img src={leftToken?.src} style={imageStyle} alt="left token" />
+                    <div style={imageDescriptionStyle}>
+                      <p style={textStyle}>{leftToken?.name}</p>
+                      <p style={boldTextStyle}>{leftToken?.ownerName}</p>
                     </div>
                   </div>
                 ) : null}
               </div>
 
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  position: 'absolute',
-                  width: '100%',
-
-                  height: '100%',
-                }}
-              >
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    width: '100%',
-                    alignItems: 'center',
-                    gap: '8px',
-                  }}
-                >
-                  <div
-                    style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-                  >
-                    <img
-                      src={centerToken?.src}
-                      style={{
-                        maxWidth: '380px',
-                        maxHeight: '380px',
-                        display: 'block',
-                        objectFit: 'contain',
-                      }}
-                      alt="center token"
-                    />
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        marginTop: 8,
-                        alignItems: 'flex-start',
-                        justifyContent: 'flex-start',
-                      }}
-                    >
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Regular'",
-                          fontSize: '14px',
-                          fontWeight: 'light',
-                          lineHeight: '20px',
-                          margin: 0,
-                        }}
-                      >
-                        {centerToken?.name}
-                      </p>
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Bold'",
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          lineHeight: '18px',
-                          margin: 0,
-                        }}
-                      >
-                        {centerToken?.ownerName}
-                      </p>
+              <div style={centeredImageContainerStyle}>
+                <div style={columnFlexStyle}>
+                  <div style={columnAltFlexStyle}>
+                    <img src={centerToken?.src} style={imageStyle} alt="center token" />
+                    <div style={imageDescriptionStyle}>
+                      <p style={textStyle}>{centerToken?.name}</p>
+                      <p style={boldTextStyle}>{centerToken?.ownerName}</p>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div
-                style={{
-                  display: 'flex',
-                  position: 'relative',
-                  marginRight: '-65%',
-                  filter: 'blur(6px)',
-                  opacity: 0.26,
-                }}
-              >
+              <div style={blurredRightSideImageStyle}>
                 {rightToken ? (
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      width: '380px',
-                    }}
-                  >
-                    <img
-                      src={rightToken?.src}
-                      style={{
-                        maxWidth: '340px',
-                        maxHeight: '380px',
-                        display: 'block',
-                        objectFit: 'contain',
-                      }}
-                      alt="right token"
-                    />
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        marginTop: 8,
-                        justifyContent: 'flex-start',
-                        filter: 'blur(2px)',
-                      }}
-                    >
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Regular'",
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          lineHeight: '20px',
-                          margin: 0,
-                        }}
-                      >
-                        {rightToken?.name}
-                      </p>
-                      <p
-                        style={{
-                          fontFamily: "'ABCDiatype-Bold'",
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          lineHeight: '20px',
-                          margin: 0,
-                        }}
-                      >
-                        {rightToken?.ownerName}
-                      </p>
+                  <div style={columnAltFlexStyle}>
+                    <img src={rightToken?.src} style={imageStyle} alt="right token" />
+                    <div style={imageDescriptionStyle}>
+                      <p style={textStyle}>{rightToken?.name}</p>
+                      <p style={boldTextStyle}>{rightToken?.ownerName}</p>
                     </div>
                   </div>
                 ) : null}
@@ -306,8 +154,8 @@ const handler = async (req: NextApiRequest) => {
             </div>
           ),
           {
-            width: 500,
-            height: 500,
+            width: WIDTH_OPENGRAPH_IMAGE,
+            height: HEIGHT_OPENGRAPH_IMAGE,
             fonts: [
               {
                 name: 'ABCDiatype-Regular',
@@ -326,200 +174,42 @@ const handler = async (req: NextApiRequest) => {
                 weight: 500,
               },
             ],
-          }
+          },
         );
       }
 
       return new ImageResponse(
         (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              width: '100%',
-              height: '100%',
-              minHeight: 200,
-              backgroundColor: '#ffffff',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                position: 'relative',
-                marginLeft: '-25%',
-                filter: 'blur(6px)',
-                opacity: 0.26,
-              }}
-            >
+          <div style={containerStyle}>
+            <div style={blurredLeftSideImageStyle}>
               {leftToken ? (
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <img
-                    width="500"
-                    height="500"
-                    src={leftToken?.src}
-                    style={{
-                      maxWidth: '500px',
-                      maxHeight: '500px',
-                      display: 'block',
-                      objectFit: 'contain',
-                    }}
-                    alt="left token"
-                  />
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'flex-start',
-                      filter: 'blur(2px)',
-                    }}
-                  >
-                    <p
-                      style={{
-                        fontFamily: "'ABCDiatype-Regular'",
-                        fontSize: '14px',
-                        fontWeight: 400,
-                        lineHeight: '20px',
-                        margin: 0,
-                      }}
-                    >
-                      {leftToken?.name}
-                    </p>
-                    <p
-                      style={{
-                        fontFamily: "'ABCDiatype-Bold'",
-                        fontSize: '14px',
-                        fontWeight: 400,
-                        lineHeight: '20px',
-                        margin: 0,
-                      }}
-                    >
-                      {leftToken?.ownerName}
-                    </p>
+                <div style={columnAltFlexStyle}>
+                  <img src={leftToken?.src} style={imageStyle} alt="left token" />
+                  <div style={imageDescriptionStyle}>
+                    <p style={textStyle}>{leftToken?.name}</p>
+                    <p style={boldTextStyle}>{leftToken?.ownerName}</p>
                   </div>
                 </div>
               ) : null}
             </div>
 
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-
-                position: 'absolute',
-                width: '100%',
-
-                height: '100%',
-              }}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '8px',
-                }}
-              >
-                <img
-                  width="500"
-                  height="500"
-                  src={centerToken?.src}
-                  style={{
-                    maxWidth: '500px',
-                    maxHeight: '500px',
-                    display: 'block',
-                    objectFit: 'contain',
-                  }}
-                  alt="center token"
-                />
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Regular'",
-                      fontSize: '14px',
-                      fontWeight: 'light',
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {centerToken?.name}
-                  </p>
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Bold'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {centerToken?.ownerName}
-                  </p>
+            <div style={centeredImageContainerStyle}>
+              <div style={columnFlexStyle}>
+                <img src={centerToken?.src} style={imageStyle} alt="center token" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{centerToken?.name}</p>
+                  <p style={boldTextStyle}>{centerToken?.ownerName}</p>
                 </div>
               </div>
             </div>
 
-            <div
-              style={{
-                display: 'flex',
-                position: 'relative',
-                marginRight: '-25%',
-                filter: 'blur(6px)',
-                opacity: 0.26,
-              }}
-            >
+            <div style={blurredRightSideImageStyle}>
               {rightToken ? (
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <img
-                    width="500"
-                    height="500"
-                    src={rightToken?.src}
-                    style={{
-                      maxWidth: '500px',
-                      maxHeight: '500px',
-                      display: 'block',
-                      objectFit: 'contain',
-                    }}
-                    alt="right token"
-                  />
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'flex-start',
-                      filter: 'blur(2px)',
-                    }}
-                  >
-                    <p
-                      style={{
-                        fontFamily: "'ABCDiatype-Regular'",
-                        fontSize: '14px',
-                        fontWeight: 400,
-                        lineHeight: '20px',
-                        margin: 0,
-                      }}
-                    >
-                      {rightToken?.name}
-                    </p>
-                    <p
-                      style={{
-                        fontFamily: "'ABCDiatype-Bold'",
-                        fontSize: '14px',
-                        fontWeight: 400,
-                        lineHeight: '20px',
-                        margin: 0,
-                      }}
-                    >
-                      {rightToken?.ownerName}
-                    </p>
+                <div style={columnAltFlexStyle}>
+                  <img src={rightToken?.src} style={imageStyle} alt="right token" />
+                  <div style={imageDescriptionStyle}>
+                    <p style={textStyle}>{rightToken?.name}</p>
+                    <p style={boldTextStyle}>{rightToken?.ownerName}</p>
                   </div>
                 </div>
               ) : null}
@@ -547,7 +237,7 @@ const handler = async (req: NextApiRequest) => {
               weight: 500,
             },
           ],
-        }
+        },
       );
     }
   } catch (e) {

--- a/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
+++ b/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
@@ -123,7 +123,7 @@ const handler = async (req: NextApiRequest) => {
               <div style={columnFlexStyle}>
                 <div style={columnAltFlexStyle}>
                   <img src={centerToken?.src} style={imageStyle} alt="center token" />
-                  <div style={imageDescriptionStyle}>
+                  <div style={columnAltFlexStyle}>
                     <p style={textStyle}>{centerToken?.name}</p>
                     <p style={boldTextStyle}>{centerToken?.ownerName}</p>
                   </div>
@@ -187,7 +187,7 @@ const handler = async (req: NextApiRequest) => {
           <div style={centeredImageContainerStyle}>
             <div style={columnFlexStyle}>
               <img src={centerToken?.src} style={imageStyle} alt="center token" />
-              <div style={imageDescriptionStyle}>
+              <div style={columnAltFlexStyle}>
                 <p style={textStyle}>{centerToken?.name}</p>
                 <p style={boldTextStyle}>{centerToken?.ownerName}</p>
               </div>

--- a/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
+++ b/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
@@ -1,5 +1,6 @@
-/* eslint-disable @next/next/no-img-element */
 import React from 'react';
+
+/* eslint-disable @next/next/no-img-element */
 import { NextApiRequest } from 'next';
 import {
   HEIGHT_OPENGRAPH_IMAGE,

--- a/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
+++ b/src/pages/api/og/community/[chain]/[contractAddress]/fcframe.tsx
@@ -12,7 +12,10 @@ import { ImageResponse } from '@vercel/og';
 import { ABCDiatypeBold, ABCDiatypeRegular, alpinaLight } from '../../../../../../utils/fonts';
 import { framePostHandler, isImageTall } from '../../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../../utils/getPreviewTokens';
-import { generateSplashImageResponse } from '../../../../../../utils/splashScreen';
+import {
+  generateSplashImageResponse,
+  shouldShowSplashScreen,
+} from '../../../../../../utils/splashScreen';
 
 import {
   containerStyle,
@@ -81,19 +84,7 @@ const handler = async (req: NextApiRequest) => {
 
     const { name: communityName, tokensForFrame: tokens } = community;
 
-    // if no position is explicitly provided, that means we should serve the splash image
-    let showSplashScreen = !position;
-
-    // if position is the end of the carousel, that means we should serve the splash image
-    if (position) {
-      const tokensLength = tokens.length ?? 0;
-      const mainPosition = Number(position) % tokensLength;
-      if (mainPosition === 0) {
-        // we've wrapped around to the start again as position has been explicitly set to 0
-        showSplashScreen = true;
-      }
-    }
-
+    let showSplashScreen = shouldShowSplashScreen({ position, carouselLength: tokens?.length + 1 });
     if (showSplashScreen) {
       return generateSplashImageResponse({
         titleText: communityName,
@@ -102,82 +93,16 @@ const handler = async (req: NextApiRequest) => {
       });
     }
 
-    if (!showSplashScreen) {
-      const tokensToDisplay = getPreviewTokens(tokens, `${Number(position) - 1}`);
+    const tokensToDisplay = getPreviewTokens(tokens, `${Number(position) - 1}`);
 
-      const leftToken = Number(position) !== 1 && tokensToDisplay?.left;
-      const centerToken = tokensToDisplay?.current;
-      const rightToken = tokensToDisplay?.right;
+    const leftToken = Number(position) !== 1 && tokensToDisplay?.left;
+    const centerToken = tokensToDisplay?.current;
+    const rightToken = tokensToDisplay?.right;
 
-      const tokenAspectRatio = centerToken?.aspectRatio;
-      const squareAspectRatio = isImageTall(tokenAspectRatio);
+    const tokenAspectRatio = centerToken?.aspectRatio;
+    const squareAspectRatio = isImageTall(tokenAspectRatio);
 
-      if (squareAspectRatio) {
-        return new ImageResponse(
-          (
-            <div style={containerStyle}>
-              <div style={blurredLeftSideImageStyle}>
-                {leftToken ? (
-                  <div style={columnAltFlexStyle}>
-                    <img src={leftToken?.src} style={imageStyle} alt="left token" />
-                    <div style={imageDescriptionStyle}>
-                      <p style={textStyle}>{leftToken?.name}</p>
-                      <p style={boldTextStyle}>{leftToken?.ownerName}</p>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-
-              <div style={centeredImageContainerStyle}>
-                <div style={columnFlexStyle}>
-                  <div style={columnAltFlexStyle}>
-                    <img src={centerToken?.src} style={imageStyle} alt="center token" />
-                    <div style={imageDescriptionStyle}>
-                      <p style={textStyle}>{centerToken?.name}</p>
-                      <p style={boldTextStyle}>{centerToken?.ownerName}</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div style={blurredRightSideImageStyle}>
-                {rightToken ? (
-                  <div style={columnAltFlexStyle}>
-                    <img src={rightToken?.src} style={imageStyle} alt="right token" />
-                    <div style={imageDescriptionStyle}>
-                      <p style={textStyle}>{rightToken?.name}</p>
-                      <p style={boldTextStyle}>{rightToken?.ownerName}</p>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          ),
-          {
-            width: WIDTH_OPENGRAPH_IMAGE,
-            height: HEIGHT_OPENGRAPH_IMAGE,
-            fonts: [
-              {
-                name: 'ABCDiatype-Regular',
-                data: ABCDiatypeRegularFontData,
-                weight: 400,
-              },
-              {
-                name: 'ABCDiatype-Bold',
-                data: ABCDiatypeBoldFontData,
-                weight: 700,
-              },
-              {
-                name: 'GT Alpina',
-                data: alpinaLightFontData,
-                style: 'normal',
-                weight: 500,
-              },
-            ],
-          },
-        );
-      }
-
+    if (squareAspectRatio) {
       return new ImageResponse(
         (
           <div style={containerStyle}>
@@ -195,10 +120,12 @@ const handler = async (req: NextApiRequest) => {
 
             <div style={centeredImageContainerStyle}>
               <div style={columnFlexStyle}>
-                <img src={centerToken?.src} style={imageStyle} alt="center token" />
-                <div style={imageDescriptionStyle}>
-                  <p style={textStyle}>{centerToken?.name}</p>
-                  <p style={boldTextStyle}>{centerToken?.ownerName}</p>
+                <div style={columnAltFlexStyle}>
+                  <img src={centerToken?.src} style={imageStyle} alt="center token" />
+                  <div style={imageDescriptionStyle}>
+                    <p style={textStyle}>{centerToken?.name}</p>
+                    <p style={boldTextStyle}>{centerToken?.ownerName}</p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -240,6 +167,68 @@ const handler = async (req: NextApiRequest) => {
         },
       );
     }
+
+    return new ImageResponse(
+      (
+        <div style={containerStyle}>
+          <div style={blurredLeftSideImageStyle}>
+            {leftToken ? (
+              <div style={columnAltFlexStyle}>
+                <img src={leftToken?.src} style={imageStyle} alt="left token" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{leftToken?.name}</p>
+                  <p style={boldTextStyle}>{leftToken?.ownerName}</p>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div style={centeredImageContainerStyle}>
+            <div style={columnFlexStyle}>
+              <img src={centerToken?.src} style={imageStyle} alt="center token" />
+              <div style={imageDescriptionStyle}>
+                <p style={textStyle}>{centerToken?.name}</p>
+                <p style={boldTextStyle}>{centerToken?.ownerName}</p>
+              </div>
+            </div>
+          </div>
+
+          <div style={blurredRightSideImageStyle}>
+            {rightToken ? (
+              <div style={columnAltFlexStyle}>
+                <img src={rightToken?.src} style={imageStyle} alt="right token" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{rightToken?.name}</p>
+                  <p style={boldTextStyle}>{rightToken?.ownerName}</p>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ),
+      {
+        width: WIDTH_OPENGRAPH_IMAGE,
+        height: HEIGHT_OPENGRAPH_IMAGE,
+        fonts: [
+          {
+            name: 'ABCDiatype-Regular',
+            data: ABCDiatypeRegularFontData,
+            weight: 400,
+          },
+          {
+            name: 'ABCDiatype-Bold',
+            data: ABCDiatypeBoldFontData,
+            weight: 700,
+          },
+          {
+            name: 'GT Alpina',
+            data: alpinaLightFontData,
+            style: 'normal',
+            weight: 500,
+          },
+        ],
+      },
+    );
   } catch (e) {
     console.log('error: ', e);
     return fallbackImageResponse;

--- a/src/pages/api/og/gallery/[galleryId].tsx
+++ b/src/pages/api/og/gallery/[galleryId].tsx
@@ -29,23 +29,10 @@ const handler = async (req: NextApiRequest) => {
       return fallbackImageResponse;
     }
 
-    // TODO(Rohan): remove these once we can support these assets
-    // temp fix to get the WLTA winner gallery frames working
-    const tempIgnoreTokensWithIds = new Set([
-      '2bT2G4iiB0LfMVZ6k3YfdiIs8sU',
-      '2bT2FzE3iB59Zm5PTUTAhM9lor7',
-      '2blxlBBmty8MFX3qLevWqOXorJX',
-      '2bhcj7DcaxAROSHodJH99glBt17',
-      '2cPoZ0hrNJbaiNsMOvLkeHrfIFc',
-      '2bT2FzEWNvgShbVLFwWDMnZ36ud',
-      '2cPoYvcYW2xsDoSHhJn9YoMFjY2',
-    ]);
-
     const tokens = gallery.collections
       .filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
-      .map((el) => el?.token)
-      .filter((token) => !tempIgnoreTokensWithIds.has(token?.dbid));
+      .map((el) => el?.token);
 
     return generateSplashImageResponse({
       titleText: gallery.name,

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -100,27 +100,20 @@ const handler = async (req: NextApiRequest) => {
 
     return new ImageResponse(
       (
-        <div style={containerStyle as CSSProperties}>
-          <div style={blurredLeftSideImageStyle as CSSProperties}>
+        <div style={containerStyle}>
+          <div style={blurredLeftSideImageStyle}>
             {leftToken ? (
               <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <img
-                  width="500"
-                  height="500"
-                  src={leftToken?.src}
-                  style={imageStyle as CSSProperties}
-                  alt="post"
-                />
-                <div style={imageDescriptionStyle as CSSProperties}>
-                  <p style={textStyle as CSSProperties}>{leftToken?.name}</p>
-                  <p style={boldTextStyle as CSSProperties}>{leftToken?.communityName}</p>
+                <img width="500" height="500" src={leftToken?.src} style={imageStyle} alt="post" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{leftToken?.name}</p>
+                  <p style={boldTextStyle}>{leftToken?.communityName}</p>
                 </div>
               </div>
             ) : null}
           </div>
-
-          <div style={centeredImageContainerStyle as CSSProperties}>
-            <div style={columnFlexStyle as CSSProperties}>
+          <div style={centeredImageContainerStyle}>
+            <div style={columnFlexStyle}>
               <img
                 width="500"
                 height="500"
@@ -128,14 +121,14 @@ const handler = async (req: NextApiRequest) => {
                 style={imageStyle as CSSProperties}
                 alt="post"
               />
-              <div style={columnAltFlexStyle as CSSProperties}>
+              <div style={columnAltFlexStyle}>
                 <p style={textStyle}>{centerToken?.name}</p>
                 <p style={boldTextStyle}>{centerToken?.communityName}</p>
               </div>
             </div>
           </div>
 
-          <div style={blurredRightSideImageStyle as CSSProperties}>
+          <div style={blurredRightSideImageStyle}>
             {rightToken ? (
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 <img
@@ -145,9 +138,9 @@ const handler = async (req: NextApiRequest) => {
                   style={imageStyle as CSSProperties}
                   alt="post"
                 />
-                <div style={imageDescriptionStyle as CSSProperties}>
-                  <p style={textStyle as CSSProperties}>{rightToken?.name}</p>
-                  <p style={boldTextStyle as CSSProperties}>{rightToken?.communityName}</p>
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{rightToken?.name}</p>
+                  <p style={boldTextStyle}>{rightToken?.communityName}</p>
                 </div>
               </div>
             ) : null}

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -12,7 +12,10 @@ import {
 import { ABCDiatypeRegular, ABCDiatypeBold, alpinaLight } from '../../../../../utils/fonts';
 import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
-import { generateSplashImageResponse } from '../../../../../utils/splashScreen';
+import {
+  generateSplashImageResponse,
+  shouldShowSplashScreen,
+} from '../../../../../utils/splashScreen';
 import {
   containerStyle,
   blurredLeftSideImageStyle,
@@ -68,9 +71,7 @@ const handler = async (req: NextApiRequest) => {
       .flatMap((collection) => collection?.tokens)
       .map((el) => el?.token);
 
-    // if no position is explicitly provided, serve splash image
-    let showSplashScreen = !position;
-
+    let showSplashScreen = shouldShowSplashScreen({ position, carouselLength: tokens?.length + 1 });
     if (showSplashScreen) {
       return generateSplashImageResponse({
         titleText: gallery.name,

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
+
 /* eslint-disable @next/next/no-img-element */
-import React, { CSSProperties } from 'react';
 import { NextApiRequest } from 'next';
 import { ImageResponse } from '@vercel/og';
 import { fetchGraphql } from '../../../../../fetch';
@@ -102,13 +103,7 @@ const handler = async (req: NextApiRequest) => {
           </div>
           <div style={centeredImageContainerStyle}>
             <div style={columnFlexStyle}>
-              <img
-                width="500"
-                height="500"
-                src={centerToken?.src}
-                style={imageStyle as CSSProperties}
-                alt="post"
-              />
+              <img width="500" height="500" src={centerToken?.src} style={imageStyle} alt="post" />
               <div style={columnAltFlexStyle}>
                 <p style={textStyle}>{centerToken?.name}</p>
                 <p style={boldTextStyle}>{centerToken?.communityName}</p>
@@ -119,13 +114,7 @@ const handler = async (req: NextApiRequest) => {
           <div style={blurredRightSideImageStyle}>
             {rightToken ? (
               <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <img
-                  width="500"
-                  height="500"
-                  src={rightToken?.src}
-                  style={imageStyle as CSSProperties}
-                  alt="post"
-                />
+                <img width="500" height="500" src={rightToken?.src} style={imageStyle} alt="post" />
                 <div style={imageDescriptionStyle}>
                   <p style={textStyle}>{rightToken?.name}</p>
                   <p style={boldTextStyle}>{rightToken?.communityName}</p>

--- a/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
+++ b/src/pages/api/og/gallery/[galleryId]/fcframe.tsx
@@ -63,23 +63,10 @@ const handler = async (req: NextApiRequest) => {
     const ABCDiatypeBoldFontData = await ABCDiatypeBold;
     const alpinaLightFontData = await alpinaLight;
 
-    // TODO(Rohan): remove these once we can support these assets
-    // temp fix to get the WLTA winner gallery frames working
-    const tempIgnoreTokensWithIds = new Set([
-      '2bT2G4iiB0LfMVZ6k3YfdiIs8sU',
-      '2bT2FzE3iB59Zm5PTUTAhM9lor7',
-      '2blxlBBmty8MFX3qLevWqOXorJX',
-      '2bhcj7DcaxAROSHodJH99glBt17',
-      '2cPoZ0hrNJbaiNsMOvLkeHrfIFc',
-      '2bT2FzEWNvgShbVLFwWDMnZ36ud',
-      '2cPoYvcYW2xsDoSHhJn9YoMFjY2',
-    ]);
-
     const tokens = gallery.collections
       .filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
-      .map((el) => el?.token)
-      .filter((token) => !tempIgnoreTokensWithIds.has(token?.dbid));
+      .map((el) => el?.token);
 
     // if no position is explicitly provided, serve splash image
     let showSplashScreen = !position;

--- a/src/pages/api/og/post/[postId]/fcframe.tsx
+++ b/src/pages/api/og/post/[postId]/fcframe.tsx
@@ -18,6 +18,19 @@ import {
 import { postIdQuery } from '../../../../../queries/postIdOpengraphQuery';
 import { NextApiRequest } from 'next';
 
+import {
+  containerStyle,
+  blurredLeftSideImageStyle,
+  blurredRightSideImageStyle,
+  centeredImageContainerStyle,
+  imageDescriptionStyle,
+  textStyle,
+  boldTextStyle,
+  imageStyle,
+  columnFlexStyle,
+  columnAltFlexStyle,
+} from '../../../../../styles';
+
 export const config = {
   runtime: 'edge',
 };
@@ -145,17 +158,7 @@ const handler = async (req: NextApiRequest) => {
 
     return new ImageResponse(
       (
-        <div
-          style={{
-            height: '100%',
-            width: '100%',
-            gap: 60,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: '#fff',
-          }}
-        >
+        <div style={containerStyle}>
           <svg
             style={{ width: '56.74px', height: '196px' }}
             viewBox="0 0 36 121"
@@ -175,23 +178,8 @@ const handler = async (req: NextApiRequest) => {
               justifyContent: 'center',
             }}
           >
-            <img
-              src={postImageUrl}
-              style={{
-                maxWidth: '450px',
-                height: '370px',
-                display: 'block',
-                objectFit: 'contain',
-              }}
-              alt="post"
-            />
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '8px',
-              }}
-            >
+            <img src={postImageUrl} style={imageStyle} alt="post" />
+            <div style={columnFlexStyle}>
               <div
                 style={{
                   display: 'flex',
@@ -228,42 +216,14 @@ const handler = async (req: NextApiRequest) => {
                     {firstLetter}
                   </div>
                 )}
-                <h1
-                  style={{
-                    fontSize: '32px',
-                    lineHeight: '36px',
-                    fontFamily: "'ABCDiatype-Bold'",
-                    letterSpacing: '-0.01em',
-                    margin: '0',
-                    paddingBottom: 4,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  {author?.username}
-                </h1>
+                <h1 style={boldTextStyle}>{author?.username}</h1>
               </div>
               <div
                 style={{
                   display: 'flex',
                 }}
               >
-                <p
-                  style={{
-                    fontFamily: "'ABCDiatype-Regular'",
-                    fontSize: '25px',
-                    fontWeight: 400,
-                    lineHeight: '32px',
-                    overflow: 'hidden',
-                    wordBreak: 'break-word',
-                    maxWidth: '350px',
-                    minWidth: '200px',
-                    margin: 0,
-                  }}
-                >
-                  {captionPlaintext}
-                </p>
+                <p style={textStyle}>{captionPlaintext}</p>
               </div>
             </div>
           </div>

--- a/src/pages/api/og/post/[postId]/fcframe.tsx
+++ b/src/pages/api/og/post/[postId]/fcframe.tsx
@@ -153,7 +153,17 @@ const handler = async (req: NextApiRequest) => {
 
     return new ImageResponse(
       (
-        <div style={containerStyle}>
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            gap: 60,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#fff',
+          }}
+        >
           <svg
             style={{ width: '56.74px', height: '196px' }}
             viewBox="0 0 36 121"

--- a/src/pages/api/og/post/[postId]/fcframe.tsx
+++ b/src/pages/api/og/post/[postId]/fcframe.tsx
@@ -1,9 +1,12 @@
-/* eslint-disable @next/next/no-img-element */
 import React from 'react';
+
+/* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from '@vercel/og';
+import { NextApiRequest } from 'next';
+import { FrameImageMetadata, FrameMetadataType, getFrameHtmlResponse } from '@coinbase/onchainkit';
+
 import { fetchGraphql, getPreviewUrl } from '../../../../../fetch';
 import { getTokenMintTarget } from '../../../../../utils/getTokenMintTarget';
-import { FrameImageMetadata, FrameMetadataType, getFrameHtmlResponse } from '@coinbase/onchainkit';
 import {
   WIDTH_OPENGRAPH_IMAGE,
   HEIGHT_OPENGRAPH_IMAGE,
@@ -14,21 +17,13 @@ import {
   CHAR_LENGTH_ONE_LINE,
   truncateAndStripMarkdown,
 } from '../../../../../utils/extractWordsWithinLimit';
-
 import { postIdQuery } from '../../../../../queries/postIdOpengraphQuery';
-import { NextApiRequest } from 'next';
-
 import {
   containerStyle,
-  blurredLeftSideImageStyle,
-  blurredRightSideImageStyle,
-  centeredImageContainerStyle,
-  imageDescriptionStyle,
   textStyle,
   boldTextStyle,
   imageStyle,
   columnFlexStyle,
-  columnAltFlexStyle,
 } from '../../../../../styles';
 
 export const config = {

--- a/src/pages/api/og/user/[username]/fcframe.tsx
+++ b/src/pages/api/og/user/[username]/fcframe.tsx
@@ -13,6 +13,18 @@ import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
 import React from 'react';
 import { fcframeUsernameOpengraphQuery } from '../../../../../queries/fcframeUsernameOpengraphQuery';
 import { generateSplashImageResponse } from '../../../../../utils/splashScreen';
+import {
+  containerStyle,
+  blurredLeftSideImageStyle,
+  blurredRightSideImageStyle,
+  centeredImageContainerStyle,
+  imageDescriptionStyle,
+  textStyle,
+  boldTextStyle,
+  imageStyle,
+  columnFlexStyle,
+  columnAltFlexStyle,
+} from '../../../../../styles';
 
 export const config = {
   runtime: 'edge',
@@ -48,8 +60,8 @@ const handler = async (req: NextApiRequest) => {
     }
 
     const tokens = user.galleries
-      ?.filter((gallery) =>
-        gallery?.collections?.some((collection) => collection?.tokens?.length)
+      ?.filter(
+        (gallery) => gallery?.collections?.some((collection) => collection?.tokens?.length),
       )?.[0]
       .collections?.filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
@@ -77,194 +89,36 @@ const handler = async (req: NextApiRequest) => {
 
     return new ImageResponse(
       (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            width: '100%',
-            height: '100%',
-            minHeight: 200,
-            backgroundColor: '#ffffff',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              marginLeft: '-25%',
-              filter: 'blur(6px)',
-              opacity: 0.26,
-            }}
-          >
+        <div style={containerStyle}>
+          <div style={blurredLeftSideImageStyle}>
             {leftToken ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <img
-                  width="500"
-                  height="500"
-                  src={leftToken?.src}
-                  style={{
-                    maxWidth: '500px',
-                    maxHeight: '500px',
-                    display: 'block',
-                    objectFit: 'contain',
-                  }}
-                  alt="post"
-                />
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    filter: 'blur(2px)',
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Regular'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {leftToken?.name}
-                  </p>
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Bold'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {leftToken?.communityName}
-                  </p>
+              <div style={columnAltFlexStyle}>
+                <img width="500" height="500" src={leftToken?.src} style={imageStyle} alt="post" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{leftToken?.name}</p>
+                  <p style={boldTextStyle}>{leftToken?.communityName}</p>
                 </div>
               </div>
             ) : null}
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-
-              position: 'absolute',
-              width: '100%',
-
-              height: '100%',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '8px',
-              }}
-            >
-              <img
-                width="500"
-                height="500"
-                src={centerToken?.src}
-                style={{
-                  maxWidth: '500px',
-                  maxHeight: '500px',
-                  display: 'block',
-                  objectFit: 'contain',
-                }}
-                alt="post"
-              />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'flex-start',
-                }}
-              >
-                <p
-                  style={{
-                    fontFamily: "'ABCDiatype-Regular'",
-                    fontSize: '14px',
-                    fontWeight: 'light',
-                    lineHeight: '20px',
-                    margin: 0,
-                  }}
-                >
-                  {centerToken?.name}
-                </p>
-                <p
-                  style={{
-                    fontFamily: "'ABCDiatype-Bold'",
-                    fontSize: '14px',
-                    fontWeight: 400,
-                    lineHeight: '20px',
-                    margin: 0,
-                  }}
-                >
-                  {centerToken?.communityName}
-                </p>
+          <div style={centeredImageContainerStyle}>
+            <div style={columnFlexStyle}>
+              <img width="500" height="500" src={centerToken?.src} style={imageStyle} alt="post" />
+              <div style={columnAltFlexStyle}>
+                <p style={textStyle}>{centerToken?.name}</p>
+                <p style={boldTextStyle}>{centerToken?.communityName}</p>
               </div>
             </div>
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              marginRight: '-25%',
-              filter: 'blur(6px)',
-              opacity: 0.26,
-            }}
-          >
+          <div style={blurredRightSideImageStyle}>
             {rightToken ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <img
-                  width="500"
-                  height="500"
-                  src={rightToken?.src}
-                  style={{
-                    maxWidth: '500px',
-                    maxHeight: '500px',
-                    display: 'block',
-                    objectFit: 'contain',
-                  }}
-                  alt="post"
-                />
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    filter: 'blur(2px)',
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Regular'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {rightToken?.name}
-                  </p>
-                  <p
-                    style={{
-                      fontFamily: "'ABCDiatype-Bold'",
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      margin: 0,
-                    }}
-                  >
-                    {rightToken?.communityName}
-                  </p>
+              <div style={columnAltFlexStyle}>
+                <img width="500" height="500" src={rightToken?.src} style={imageStyle} alt="post" />
+                <div style={imageDescriptionStyle}>
+                  <p style={textStyle}>{rightToken?.name}</p>
+                  <p style={boldTextStyle}>{rightToken?.communityName}</p>
                 </div>
               </div>
             ) : null}
@@ -286,7 +140,7 @@ const handler = async (req: NextApiRequest) => {
             weight: 700,
           },
         ],
-      }
+      },
     );
   } catch (e) {
     console.log('error: ', e);

--- a/src/pages/api/og/user/[username]/fcframe.tsx
+++ b/src/pages/api/og/user/[username]/fcframe.tsx
@@ -12,7 +12,10 @@ import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
 import React from 'react';
 import { fcframeUsernameOpengraphQuery } from '../../../../../queries/fcframeUsernameOpengraphQuery';
-import { generateSplashImageResponse } from '../../../../../utils/splashScreen';
+import {
+  generateSplashImageResponse,
+  shouldShowSplashScreen,
+} from '../../../../../utils/splashScreen';
 import {
   containerStyle,
   blurredLeftSideImageStyle,
@@ -67,9 +70,7 @@ const handler = async (req: NextApiRequest) => {
       .flatMap((collection) => collection?.tokens)
       .map((el) => el?.token);
 
-    // if no position is explicitly provided, serve splash image
-    let showSplashScreen = !position;
-
+    let showSplashScreen = shouldShowSplashScreen({ position, carouselLength: tokens?.length + 1 });
     if (showSplashScreen) {
       return generateSplashImageResponse({
         titleText: username,

--- a/src/pages/api/og/user/[username]/fcframe.tsx
+++ b/src/pages/api/og/user/[username]/fcframe.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from '@vercel/og';
 import { fetchGraphql } from '../../../../../fetch';
@@ -10,7 +12,6 @@ import {
 import { ABCDiatypeRegular, ABCDiatypeBold } from '../../../../../utils/fonts';
 import { framePostHandler } from '../../../../../utils/framePostHandler';
 import { getPreviewTokens } from '../../../../../utils/getPreviewTokens';
-import React from 'react';
 import { fcframeUsernameOpengraphQuery } from '../../../../../queries/fcframeUsernameOpengraphQuery';
 import {
   generateSplashImageResponse,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,6 @@
-export const containerStyle = {
+import { CSSProperties } from 'react';
+
+export const containerStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'row',
   width: '100%',
@@ -9,7 +11,7 @@ export const containerStyle = {
   alignItems: 'center',
 };
 
-export const blurredLeftSideImageStyle = {
+export const blurredLeftSideImageStyle: CSSProperties = {
   display: 'flex',
   position: 'relative',
   marginLeft: '-25%',
@@ -17,7 +19,7 @@ export const blurredLeftSideImageStyle = {
   opacity: 0.26,
 };
 
-export const centeredImageContainerStyle = {
+export const centeredImageContainerStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
@@ -27,7 +29,7 @@ export const centeredImageContainerStyle = {
   height: '100%',
 };
 
-export const blurredRightSideImageStyle = {
+export const blurredRightSideImageStyle: CSSProperties = {
   display: 'flex',
   position: 'relative',
   marginRight: '-25%',
@@ -35,14 +37,14 @@ export const blurredRightSideImageStyle = {
   opacity: 0.26,
 };
 
-export const imageDescriptionStyle = {
+export const imageDescriptionStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'flex-start',
   filter: 'blur(2px)',
 };
 
-export const textStyle = {
+export const textStyle: CSSProperties = {
   fontFamily: "'ABCDiatype-Regular'",
   fontSize: '14px',
   fontWeight: 400,
@@ -50,7 +52,7 @@ export const textStyle = {
   margin: 0,
 };
 
-export const boldTextStyle = {
+export const boldTextStyle: CSSProperties = {
   fontFamily: "'ABCDiatype-Bold'",
   fontSize: '14px',
   fontWeight: 400,
@@ -58,20 +60,20 @@ export const boldTextStyle = {
   margin: 0,
 };
 
-export const imageStyle = {
+export const imageStyle: CSSProperties = {
   maxWidth: '500px',
   maxHeight: '500px',
   display: 'block',
   objectFit: 'contain',
 };
 
-export const columnFlexStyle = {
+export const columnFlexStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: '8px',
 };
 
-export const columnAltFlexStyle = {
+export const columnAltFlexStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
 };

--- a/src/utils/getPreviewTokens.ts
+++ b/src/utils/getPreviewTokens.ts
@@ -57,11 +57,10 @@ export const getPreviewTokens = (allTokens: any[], position: string | null) => {
   // `left` will safely never be a negative value since we handled the `mainPosition` 0 case above
   const left = tokens[mainPosition - 1];
   const current = tokens[mainPosition];
-  // `right` may overflow beyond the length of the set if `current` is the last element.
-  // in this case, `right` should simply be the first element to represent wrap-around.
-  let right = mainPosition + 1 >= tokens.length ? tokens[0] : tokens[mainPosition + 1];
+  const right = tokens[mainPosition + 1];
 
-  // handle splash position separately (left token will be null as splash screen comes next)
+  // `right` may overflow beyond the length of the set if `current` is the last element.
+  // handle last position separately (right token will be null as splash screen comes next)
   if (mainPosition === tokensLength - 1) {
     return { left, current, right: null };
   }

--- a/src/utils/getPreviewTokens.ts
+++ b/src/utils/getPreviewTokens.ts
@@ -17,6 +17,8 @@ export const getPreviewTokens = (allTokens: any[], position: string | null) => {
     }
   });
   const tokensLength = tokens.length ?? 0;
+  const carouselLength = tokensLength + 1;
+
   if (tokensLength === 1) {
     const current = tokens[0];
     return { left: null, current, right: null };
@@ -31,7 +33,7 @@ export const getPreviewTokens = (allTokens: any[], position: string | null) => {
   }
 
   // handle tokensLength === 2 separately
-  const mainPosition = Number(position) % tokensLength;
+  const mainPosition = Number(position) % carouselLength;
   if (tokensLength === 2) {
     if (mainPosition === 0) {
       const current = tokens[0];
@@ -44,15 +46,11 @@ export const getPreviewTokens = (allTokens: any[], position: string | null) => {
     }
   }
 
-  // if `position` is explicitly set to be the beginning, we'll want to include the
-  // last token in set as `left` in order to represent a wrap-around effect. we only
-  // do this if a position is set as we assume the user has manually clicked through
-  // the entire set.
+  // handle first position separately (left token will be null as splash screen comes before)
   if (mainPosition === 0) {
-    const left = tokens[tokensLength - 1];
     const current = tokens[0];
     const right = tokens[1];
-    return { left, current, right };
+    return { left: null, current, right };
   }
 
   // for any other position:
@@ -61,7 +59,12 @@ export const getPreviewTokens = (allTokens: any[], position: string | null) => {
   const current = tokens[mainPosition];
   // `right` may overflow beyond the length of the set if `current` is the last element.
   // in this case, `right` should simply be the first element to represent wrap-around.
-  const right = mainPosition + 1 >= tokens.length ? tokens[0] : tokens[mainPosition + 1];
+  let right = mainPosition + 1 >= tokens.length ? tokens[0] : tokens[mainPosition + 1];
+
+  // handle splash position separately (left token will be null as splash screen comes next)
+  if (mainPosition === tokensLength - 1) {
+    return { left, current, right: null };
+  }
 
   return { left, current, right };
 };

--- a/src/utils/splashScreen.tsx
+++ b/src/utils/splashScreen.tsx
@@ -371,3 +371,15 @@ export async function generateSplashImageResponse({
     },
   );
 }
+
+type ShouldShowSplashScreenProps = {
+  position?: string;
+  carouselLength?: number;
+};
+
+export function shouldShowSplashScreen({
+  position,
+  carouselLength = 1,
+}: ShouldShowSplashScreenProps): boolean {
+  return !position || Number(position) % carouselLength === 0;
+}


### PR DESCRIPTION
## Sumary of changes


* cleaned up inline styling and other things for all `fcframe` routes, so they're a lot more readable now
* carousel works correctly now!
** loops to start after last token
** you don't see a left token in the first carousel item and a right token in the last carousel item

## Demo

https://github.com/gallery-so/opengraph/assets/49758803/25a37eb5-0445-4ce8-b7b3-df5b30b8cdc3

Other frames still working correctly, shared two here
<img width="600" alt="Screenshot 2024-05-08 at 00 04 58" src="https://github.com/gallery-so/opengraph/assets/49758803/bc36a603-0cab-4f5d-a488-9cabf7c8576d">
<img width="600" alt="Screenshot 2024-05-08 at 00 05 26" src="https://github.com/gallery-so/opengraph/assets/49758803/42da4793-0a4b-4a00-bc42-cac35d6fb0c3">

